### PR TITLE
Add recommender api

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ apiGateway.stats.getTotalUsers()
   * [`randomNewItemsBySite(params)`](https://build.envato.com/api/#market_RandomNewFiles)
 * recommender
   * `getRecommendedItems(itemId)`
+  * `getRecommendedSearches(term, site)`
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ apiGateway.stats.getTotalUsers()
   * [`getNewfilesBySiteAndCategory(params)`](https://build.envato.com/api/#!/market/NewFiles)
   * [`findFeaturedItemsBySite(site)`](https://build.envato.com/api/#market_Features)
   * [`randomNewItemsBySite(params)`](https://build.envato.com/api/#market_RandomNewFiles)
-* _coming soon_
+* recommender
+  * `getRecommendedItems(itemId)`
 
 ## Development
 

--- a/lib/catalog.js
+++ b/lib/catalog.js
@@ -1,4 +1,4 @@
-var querystring = require('querystring')
+const querystring = require('querystring')
 
 function Catalog (request) {
   if (!(this instanceof Catalog)) {

--- a/lib/catalog.js
+++ b/lib/catalog.js
@@ -91,7 +91,7 @@ Catalog.prototype = {
   },
 
   /**
-   * get tiem prices by ID
+   * get item prices by ID
    * @param  {Integer/Object} id
    * @return {Promise}
    */

--- a/lib/catalog.js
+++ b/lib/catalog.js
@@ -1,4 +1,4 @@
-const querystring = require('querystring')
+var querystring = require('querystring')
 
 function Catalog (request) {
   if (!(this instanceof Catalog)) {
@@ -103,7 +103,7 @@ Catalog.prototype = {
       id = id.id
     }
 
-    return this._request.get('/market/item-prices:${id}.json')
+    return this._request.get('/market/item-prices:' + id + '.json')
   },
 
   /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,8 @@ var axios = require('axios')
  */
 var resources = {
   stats: require('./stats'),
-  catalog: require('./catalog')
+  catalog: require('./catalog'),
+  recommender: require('./recommender')
 }
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
-var is = require('is')
-var axios = require('axios')
+const is = require('is')
+const axios = require('axios')
 
 /**
  * The APIs exposed to the user.

--- a/lib/recommender.js
+++ b/lib/recommender.js
@@ -1,3 +1,5 @@
+const querystring = require('querystring')
+
 function Recommender (request) {
   if (!(this instanceof Recommender)) {
     return new Recommender(request)
@@ -21,6 +23,28 @@ Recommender.prototype = {
     }
 
     return this._request.get('/recommendations/api/items/${itemId}')
+  },
+
+  /**
+   * get related item IDs by Item ID
+   * @param  {String/Object} term
+   * @param  {String/Object} site
+   * @return {Promise}
+   */
+  getRecommendedSearches: function (term, site) {
+    if (!term) throw new Error('term is required.')
+    // handle object type
+    if (typeof term === 'object' && term.term) {
+      term = term.term
+    }
+
+    if (!site) throw new Error('Site name is required.')
+    // handle object type
+    if (typeof site === 'object' && site.site) {
+      site = site.site
+    }
+    var qs = querystring.stringify({ site: site })
+    return this._request.get('/recommendations/api/searches/${term}?' + qs)
   }
 }
 

--- a/lib/recommender.js
+++ b/lib/recommender.js
@@ -1,0 +1,27 @@
+function Recommender (request) {
+  if (!(this instanceof Recommender)) {
+    return new Recommender(request)
+  }
+
+  this._request = request
+}
+
+Recommender.prototype = {
+  /**
+   * get related item IDs by Item ID
+   * @param  {Integer/Object} ItemId
+   * @return {Promise}
+   */
+  getRecommendedItems: function (itemId) {
+    if (!itemId) throw new Error('Item ID is required.')
+
+    // handle object type
+    if (typeof itemId === 'object' && itemId.id) {
+      itemId = itemId.id
+    }
+
+    return this._request.get('/recommendations/api/items/${itemId}')
+  }
+}
+
+module.exports = Recommender

--- a/lib/recommender.js
+++ b/lib/recommender.js
@@ -1,4 +1,4 @@
-const querystring = require('querystring')
+var querystring = require('querystring')
 
 function Recommender (request) {
   if (!(this instanceof Recommender)) {
@@ -22,7 +22,7 @@ Recommender.prototype = {
       itemId = itemId.id
     }
 
-    return this._request.get('/recommendations/api/items/${itemId}')
+    return this._request.get('/recommendations/api/items/' + itemId)
   },
 
   /**
@@ -44,7 +44,7 @@ Recommender.prototype = {
       site = site.site
     }
     var qs = querystring.stringify({ site: site })
-    return this._request.get('/recommendations/api/searches/${term}?' + qs)
+    return this._request.get('/recommendations/api/searches/' + term + '?' + qs)
   }
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,6 +4,7 @@ const noop = function () {}
 const ApiGateway = require('../lib/')
 const stats = require('../lib/stats')
 const catalog = require('../lib/catalog')
+const recommender = require('../lib/recommender')
 
 test('new ApiGateway instance', function (t) {
   t.test('should throw if missing access token', function (assert) {
@@ -29,6 +30,7 @@ test('new ApiGateway instance', function (t) {
 
     assert.equal(apiGateway.stats instanceof stats, true, 'should create new stats instance')
     assert.equal(apiGateway.catalog instanceof catalog, true, 'should create new catalog instance')
+    assert.equal(apiGateway.recommender instanceof recommender, true, 'should create new recommender instance')
 
     assert.end()
   })
@@ -43,6 +45,7 @@ test('new ApiGateway instance', function (t) {
 
     assert.equal(apiGateway.stats instanceof stats, true, 'should create new stats instance')
     assert.equal(apiGateway.catalog instanceof catalog, true, 'should create new catalog instance')
+    assert.equal(apiGateway.recommender instanceof recommender, true, 'should create new recommender instance')
 
     assert.end()
   })

--- a/test/recommender.test.js
+++ b/test/recommender.test.js
@@ -1,0 +1,43 @@
+const test = require('tape')
+const utils = require('./testUtils')
+const noop = function () {}
+const util = require('util')
+
+const ApiGateway = require('../lib/')
+
+test('recommender resource', function (t) {
+  const apiGateway = new ApiGateway('dummy token')
+
+  t.equal(typeof apiGateway.recommender.getRecommendedItems, 'function', 'should have getRecommendedItems method')
+
+  t.test('should throw if missing itemId', function (assert) {
+    assert.plan(1)
+    var itemId = undefined
+
+    assert.throws(function () {
+      var itemId = undefined
+
+      noop(apiGateway.recommender.getRecommendedItems(itemId))
+    }, 'shoud throw')
+    assert.end()
+  })
+
+  t.test('should get recommended Item ID(s)', function (assert) {
+    var itemId = 1
+    assert.plan(2)
+
+    const getRecommendedItemsRequest = apiGateway.recommender.getRecommendedItems(itemId)
+    assert.equal(utils.isPromise(getRecommendedItemsRequest), true, 'should return a promise')
+
+    getRecommendedItemsRequest
+      .then(function () {
+        // todo: use sinon to check function not called
+        noop()
+      })
+      .catch(function (err) {
+        assert.equal(err.status, 403, 'should get 403 error')
+      })
+  })
+
+  t.end()
+})

--- a/test/recommender.test.js
+++ b/test/recommender.test.js
@@ -1,7 +1,6 @@
 const test = require('tape')
 const utils = require('./testUtils')
 const noop = function () {}
-const util = require('util')
 
 const ApiGateway = require('../lib/')
 const apiGateway = new ApiGateway('dummy token')
@@ -13,8 +12,7 @@ test('Recommender.getRecommendedItems()', function (t) {
     assert.plan(1)
 
     assert.throws(function () {
-      var itemId = undefined
-      noop(apiGateway.recommender.getRecommendedItems(itemId))
+      noop(apiGateway.recommender.getRecommendedItems())
     }, 'shoud throw')
     assert.end()
   })
@@ -45,10 +43,7 @@ test('Recommender.getRecommendedSearches()', function (t) {
   t.test('should throw if missing term', function (assert) {
     assert.plan(1)
     assert.throws(function () {
-      var term = undefined
-      var site = 'themeforest.net'
-
-      noop(apiGateway.recommender.getRecommendedSearches(term, site))
+      noop(apiGateway.recommender.getRecommendedSearches(undefined, 'themeforest.net'))
     }, 'shoud throw')
     assert.end()
   })
@@ -56,10 +51,7 @@ test('Recommender.getRecommendedSearches()', function (t) {
   t.test('should throw if missing site', function (assert) {
     assert.plan(1)
     assert.throws(function () {
-      var term = 'hello'
-      var site = undefined
-
-      noop(apiGateway.recommender.getRecommendedSearches(term, site))
+      noop(apiGateway.recommender.getRecommendedSearches('term', undefined))
     }, 'shoud throw')
     assert.end()
   })

--- a/test/recommender.test.js
+++ b/test/recommender.test.js
@@ -4,19 +4,16 @@ const noop = function () {}
 const util = require('util')
 
 const ApiGateway = require('../lib/')
+const apiGateway = new ApiGateway('dummy token')
 
-test('recommender resource', function (t) {
-  const apiGateway = new ApiGateway('dummy token')
-
+test('Recommender.getRecommendedItems()', function (t) {
   t.equal(typeof apiGateway.recommender.getRecommendedItems, 'function', 'should have getRecommendedItems method')
 
   t.test('should throw if missing itemId', function (assert) {
     assert.plan(1)
-    var itemId = undefined
 
     assert.throws(function () {
       var itemId = undefined
-
       noop(apiGateway.recommender.getRecommendedItems(itemId))
     }, 'shoud throw')
     assert.end()
@@ -30,6 +27,53 @@ test('recommender resource', function (t) {
     assert.equal(utils.isPromise(getRecommendedItemsRequest), true, 'should return a promise')
 
     getRecommendedItemsRequest
+      .then(function () {
+        // todo: use sinon to check function not called
+        noop()
+      })
+      .catch(function (err) {
+        assert.equal(err.status, 403, 'should get 403 error')
+      })
+  })
+
+  t.end()
+})
+
+test('Recommender.getRecommendedSearches()', function (t) {
+  t.equal(typeof apiGateway.recommender.getRecommendedSearches, 'function', 'should have getRecommendedSearches method')
+
+  t.test('should throw if missing term', function (assert) {
+    assert.plan(1)
+    assert.throws(function () {
+      var term = undefined
+      var site = 'themeforest.net'
+
+      noop(apiGateway.recommender.getRecommendedSearches(term, site))
+    }, 'shoud throw')
+    assert.end()
+  })
+
+  t.test('should throw if missing site', function (assert) {
+    assert.plan(1)
+    assert.throws(function () {
+      var term = 'hello'
+      var site = undefined
+
+      noop(apiGateway.recommender.getRecommendedSearches(term, site))
+    }, 'shoud throw')
+    assert.end()
+  })
+
+  t.test('should get recommended search terms', function (assert) {
+    var term = 'responsive'
+    var site = 'themeforest.net'
+
+    assert.plan(2)
+
+    const getRecommendedSearchesRequest = apiGateway.recommender.getRecommendedSearches(term, site)
+    assert.equal(utils.isPromise(getRecommendedSearchesRequest), true, 'should return a promise')
+
+    getRecommendedSearchesRequest
       .then(function () {
         // todo: use sinon to check function not called
         noop()


### PR DESCRIPTION
This PR provides interfaces for 2 Recommendation API endpoints:
- `/v1/recommendations/api/items/${itemId}`
- `/v1/rrecommendations/api/searches/${term}?site=${site}`
