### PR TITLE
Fix the url of public_search_api

### DIFF
--- a/lib/catalog.js
+++ b/lib/catalog.js
@@ -43,7 +43,7 @@ Catalog.prototype = {
     if (typeof params !== 'object') throw new Error('Params should be an object')
 
     var qs = querystring.stringify(params)
-    return this._request.get('/v1/discovery/search/search/item?' + qs)
+    return this._request.get('/v1/discovery/search/api/item?' + qs)
   },
 
   /**
@@ -55,7 +55,7 @@ Catalog.prototype = {
     if (typeof params !== 'object') throw new Error('Params should be an object')
 
     var qs = querystring.stringify(params)
-    return this._request.get('/v1/discovery/search/search/comment?' + qs)
+    return this._request.get('/v1/discovery/search/api/comment?' + qs)
   },
 
   /**


### PR DESCRIPTION
The URL of the Public Search API is not correct, I could tell that you get the URL from the output of API call in build.envato.com. Unfortunately the displayed URL there is not correct (although the backend call correctly to the Public Search API endpoint)
