### PR TITLE
Fix the userAccountDetails API endpoint

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -15,7 +15,7 @@ User.prototype = {
   getAccountDetails: function (username) {
     if (!username) throw new Error('Username is required.')
 
-    return this._request.get('/v1/market/username:' + username + '.json')
+    return this._request.get('/v1/market/user:' + username + '.json')
   }
 }
 


### PR DESCRIPTION
In the previous PR, I made a mistake with endpoint URL. It should be `user` instead of `username`
